### PR TITLE
fix build on cpu container

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,0 +1,5 @@
+build_type:
+  - "cpu"
+
+pytorch_select_version:
+  - "1.0"

--- a/recipe/0301-fix-tests.patch
+++ b/recipe/0301-fix-tests.patch
@@ -1,13 +1,12 @@
 diff --git a/requirements/test.txt b/requirements/test.txt
-index c8257bd..8437ab6 100644
+index 84aa2bc..dedba36 100644
 --- a/requirements/test.txt
 +++ b/requirements/test.txt
-@@ -12,6 +12,5 @@ pre-commit>=1.0
- mypy
- yapf
+@@ -11,5 +11,4 @@ pre-commit>=1.0
+ mypy>=0.790
+ yapf>=0.29.0
  
 -atari-py==0.2.6  # needed for RL
- 
 -scikit-learn>=0.23
 \ No newline at end of file
 +scikit-learn>=0.23

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 1
+  number: 2
   string: py_{{ PKG_BUILDNUM }}
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
@@ -25,6 +25,8 @@ requirements:
     - pytorch-lightning {{ pytorch_lightning }}
 
 test:
+  requires:
+    - _pytorch_select  {{ pytorch_select_version }}
   imports:
     - pl_bolts
 

--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -2,7 +2,7 @@ tests:
   - name: Setup PyTorch-Lightning-Bolts Tests
     command: |
         git clone -b $(python -c "import pl_bolts; print(pl_bolts.__version__)") https://github.com/PyTorchLightning/pytorch-lightning-bolts.git
-        conda install -y git pytest regex typed-ast scipy scikit-learn
+        conda install -y git pytest regex typed-ast scipy scikit-learn pillow=8.2.0
 {% if python=='3.6' %}
         conda install -y dataclasses
 {% endif %}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Recipe tests failed on CPU container with the following error:

```
from torch._C import *
ImportError: libcupti.so.10.2: cannot open shared object file: No such file or directory
Tests failed for pytorch-lightning-bolts-0.3.3-py_1.tar.bz2 - moving package to /opt/conda/conda-bld/broken
WARNING:conda_build.build:Tests failed for pytorch-lightning-bolts-0.3.3-py_1.tar.bz2 - moving package to /opt/conda/conda-bld/broken
WARNING conda_build.build:tests_failed(2895): Tests failed for pytorch-lightning-bolts-0.3.3-py_1.tar.bz2 - moving package to /opt/conda/conda-bld/broken
export PREFIX=/opt/conda/conda-bld/pytorch-lightning-bolts_1625813837047/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac
export SRC_DIR=/opt/conda/conda-bld/pytorch-lightning-bolts_1625813837047/test_tmp
import: 'pl_bolts'
TESTS FAILED: pytorch-lightning-bolts-0.3.3-py_1.tar.bz2
```
because it used `cuda pytorch-base`.  And `import torch` fails for `cuda pytorch-base` on CPU container due to unavailability of CUDA libs.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
