### PR TITLE
pin setuptools and wheel to resolve build failure

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0100-remove-moco-model.patch
 
 build:
-  number: 1
+  number: 2
   string: pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
@@ -21,6 +21,8 @@ requirements:
   host:
     - pip {{ pip }}
     - python 
+    - setuptools {{ setuptools }}
+    - wheel 0.38
   run:
     - python
     - pytorch-base {{ pytorch }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Pin setuptools to fix the following error:
```
_in_process.py prepare_metadata_for_build_wheel /tmp/tmpuy4vocjh
    error in lightning-bolts setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
```

and use wheel 0.38 to fix below error:
```
        raise ParserSyntaxError(
    wheel.vendored.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after version specifier)
        torchvision>=0.10.*
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
